### PR TITLE
cookie: Email is not part of cookie

### DIFF
--- a/app/account/controller_auth.py
+++ b/app/account/controller_auth.py
@@ -28,7 +28,6 @@ def authenticate(email, password):
             return False
 
         user_uid = user.uid
-        session['user_email'] = user.email
 
         access_token = create_access_token(user_uid)
         session['access_token'] = access_token.uid.hex

--- a/features/account.feature
+++ b/features/account.feature
@@ -32,7 +32,6 @@ Feature: Account
     and we reset password to "Password123" for user "admin@test.vls"
     When user "admin@test.vls" sign in with password "Password123"
     Then return status is "200"
-    And cookie contains key "user_email" with value "admin@test.vls"
     And "access_token" for user "admin@test.vls" is valid (cookie)
     And "renew_access_token" for user "admin@test.vls" is valid (cookie)
 

--- a/features/steps/account_steps.py
+++ b/features/steps/account_steps.py
@@ -133,15 +133,6 @@ def step_impl(context, user_mail, password):
     context.vls['response'] = sign_in_user(context.vls['client'], user_mail, password)
 
 
-@then(u'cookie contains key "{key}" with value "{value}"')
-def step_impl(context, key, value):
-    "Check key, value in cookie"
-
-    with context.vls['session'].session_transaction() as sess:
-        assert key in sess
-        assert_that(sess[key], equal_to(value))
-
-
 @then(u'"{token_type}" for user "{user_mail}" is valid (cookie)')
 def step_impl(context, token_type, user_mail):
     """Check token cookie"""


### PR DESCRIPTION
label: bug

GDPR is now in the game, so, we want to protect sensitive data as muchi
as possible. Our cookies are encrypted, but still, there is no reason
to store user email in the cookie. Actually, we obtain the user from
tokens.