### PR TITLE
volesilla_utils: check db schema

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -6,6 +6,14 @@ import uuid
 from app.extensions import DB, UUID
 
 
+class Internal(DB.Model):
+    """User data model"""
+
+    uid = DB.Column(UUID, primary_key=True, default=uuid.uuid4)
+    db_version = DB.Column(DB.Integer, nullable=False)
+    updated_at = DB.Column(DB.DateTime())
+
+
 class User(DB.Model):
     """User data model"""
 


### PR DESCRIPTION
label: feature

There is new table called internal in our DB schema. This table
contains information about used database schema version and timestamp
when was database upgraded to this schema version.

Additionaly, this patch adds new command check to volesilla_utils which
compares schema version in volesilla application and in the given
database file.

This patch is first step to updating scripts for database schema which
we need for enterprise deployment.

Resolves #43